### PR TITLE
Migrate images and attachments

### DIFF
--- a/partkeepr.py
+++ b/partkeepr.py
@@ -8,6 +8,11 @@ api = "/api/parts"
 searchfilter = '?filter={"property":"name","operator":"LIKE","value":"%s%%"}'
 auth=('gilham','gilham')
 
+class attachment(object):
+    def __init__(self, data):
+        self.url = server + data['@id'] + '/getFile'
+        self.filename = data['originalFilename']
+        self.isImage = data['isImage']
 
 class part(object):
     def __init__(self,req):
@@ -53,8 +58,14 @@ class part(object):
         except (TypeError, IndexError):
             self.price = 0
 
-
-
+        self.attachments = []
+        self.image = None
+        for d in req['attachments']:
+            a = attachment(d)
+            if not self.image and a.isImage:
+                self.image = a
+            else:
+                self.attachments.append(a)
 
     def getValues(self):
         return [self.category,self.name,self.description,self.footprint]


### PR DESCRIPTION
The first image attachment will be used as the image of the part. All
other attachments will be uploaded as attachments to that part.

The InvenTree python module requires a local file to obtain the
filename, so each file is only downloaded when needed into a temporary
directory and removed afterwards.

I've put this in a separate PR as the implementation is a bit more involved.
So if some discussions are needed at least the other changes can be merged.